### PR TITLE
feat(SessionManagement): Add a SessionServer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "editor.formatOnSave": true
+  "editor.formatOnSave": false
 }

--- a/lib/hand_raise/application.ex
+++ b/lib/hand_raise/application.ex
@@ -12,9 +12,9 @@ defmodule HandRaise.Application do
       HandRaise.Repo,
       # Start the endpoint when the application starts
       HandRaiseWeb.Endpoint,
-      HandRaise.Presence
-      # Starts a worker by calling: HandRaise.Worker.start_link(arg)
-      # {HandRaise.Worker, arg},
+      HandRaise.Presence,
+      # The supervision tree for managing app sessions
+      HandRaise.SessionServer.DynamicSupervisor
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/lib/hand_raise/session_server/dynamic_supervisor.ex
+++ b/lib/hand_raise/session_server/dynamic_supervisor.ex
@@ -1,0 +1,28 @@
+defmodule HandRaise.SessionServer.DynamicSupervisor do
+  @moduledoc """
+  Supervision tree for HandRaise.SessionServer.Session servers. We use a
+  DynamicSupervisor so that we can start Sessions on demand.
+  """
+
+  use DynamicSupervisor
+
+  # API
+
+  def start_link(arg) do
+    DynamicSupervisor.start_link(__MODULE__, arg, name: __MODULE__)
+  end
+
+  def start_child(spec) do
+    DynamicSupervisor.start_child(__MODULE__, spec)
+  end
+
+  def terminate_child(pid) do
+    DynamicSupervisor.terminate_child(__MODULE__, pid)
+  end
+
+  # Callbacks
+
+  def init(_) do
+    DynamicSupervisor.init(strategy: :one_for_one)
+  end
+end

--- a/lib/hand_raise/session_server/session.ex
+++ b/lib/hand_raise/session_server/session.ex
@@ -1,0 +1,91 @@
+defmodule HandRaise.SessionServer.Session do
+  @moduledoc """
+  GenServer implementation to encapsulate a HandRaise Session, plus an API for
+  interacting with Sessions. Tracks membership state (i.e. `users`), including
+  whether or not a user has their hand raised.
+  """
+
+  use GenServer
+
+  alias Ecto.UUID
+  alias HandRaise.SessionServer.{DynamicSupervisor, User}
+
+  defstruct [
+    :id,
+    users: []
+  ]
+
+  # DynamicSupervisor management
+
+  @doc """
+  Starts an instance of __MODULE__ as a child of HandRaise.SessionServer.DynamicSupervisor.
+  This function will result in an invocation of #start_link/1
+  """
+  def start() do
+    session_id = UUID.generate()
+    spec = Supervisor.child_spec({__MODULE__, [id: session_id]}, id: {__MODULE__, session_id})
+    DynamicSupervisor.start_child(spec)
+  end
+
+  @doc """
+  Terminates an instance of __MODULE__ that is a child of HandRaise.SessionServer.DynamicSupervisor
+  """
+  def terminate(pid), do: DynamicSupervisor.terminate_child(pid)
+
+  # API
+
+  def start_link(kwl \\ []) do
+    state = struct(__MODULE__, Map.new(kwl))
+    GenServer.start_link(__MODULE__, state)
+  end
+
+  def join(pid, name), do: GenServer.call(pid, {:join, name})
+
+  def leave(pid, id), do: GenServer.cast(pid, {:leave, id})
+
+  def toggle_raise(pid, id), do: GenServer.cast(pid, {:toggle_raise, id})
+
+  def get_user(pid, id), do: GenServer.call(pid, {:get_user, id})
+
+  def get_state(pid), do: GenServer.call(pid, :get_state)
+
+  # Callbacks
+
+  def init(%__MODULE__{} = state) do
+    Process.flag(:trap_exit, true)
+    {:ok, state}
+  end
+
+  def handle_call({:join, name}, _from, %__MODULE__{users: users} = state) do
+    user = User.new(name: name)
+    {:reply, user, %__MODULE__{state | users: [user | users]}}
+  end
+  def handle_call({:get_user, id}, _from, %__MODULE__{users: users} = state) do
+    {:reply, User.find(users, id), state}
+  end
+  def handle_call(:get_state, _from, state) do
+    {:reply, state, state}
+  end
+
+  def handle_cast({:toggle_raise, id}, %__MODULE__{users: users} = state) do
+    next_users =
+      users
+      |> Enum.map(fn
+        %User{id: uid} = user when uid == id ->
+          User.toggle_raised(user)
+
+        user ->
+          user
+      end)
+
+    {:noreply, %__MODULE__{state | users: next_users}}
+  end
+  def handle_cast({:leave, id}, %__MODULE__{users: users} = state) do
+    next_users = users |> Enum.filter(&(&1.id != id))
+    {:noreply, %__MODULE__{state | users: next_users}}
+  end
+
+  def terminate(reason, %__MODULE__{id: id}) do
+    IO.puts("Session server #{id} shutting down for reason: #{reason}")
+  end
+end

--- a/lib/hand_raise/session_server/user.ex
+++ b/lib/hand_raise/session_server/user.ex
@@ -1,0 +1,23 @@
+defmodule HandRaise.SessionServer.User do
+  alias Ecto.UUID
+
+  defstruct [
+    :name,
+    :id,
+    is_raised: false
+  ]
+
+  def new(kwl \\ []) do
+    struct(__MODULE__, Map.new(kwl))
+    |> Map.put(:id, UUID.generate())
+  end
+
+  def find(users, id) do
+    users
+    |> Enum.find(fn %__MODULE__{id: uid} -> uid == id end)
+  end
+
+  def toggle_raised(%__MODULE__{is_raised: is_raised} = user) do
+    %__MODULE__{user | is_raised: !is_raised}
+  end
+end

--- a/test/hand_raise/session_server/session_test.exs
+++ b/test/hand_raise/session_server/session_test.exs
@@ -1,0 +1,82 @@
+defmodule HandRaise.SessionServer.SessionTest do
+  use HandRaise.DataCase
+
+  alias HandRaise.SessionServer.{Session, User}
+
+  describe "#start/0" do
+    test "It starts an empty Session managed by HandRaise.SessionServer.DynamicSupervisor" do
+      {:ok, _} = Session.start()
+    end
+  end
+
+  describe "#terminate/1" do
+    test "It terminates a Session by HandRaise.SessionServer.DynamicSupervisor" do
+      {:ok, pid} = Session.start()
+      :ok = Session.terminate(pid)
+    end
+  end
+
+  describe "#join/2" do
+    setup [:setup_session]
+
+    test "A new user can join the Session", %{session: session} do
+      %User{} = user = Session.join(session, "Jane Doe")
+      assert user.name == "Jane Doe"
+      assert user.is_raised == false
+    end
+  end
+
+  describe "#toggle_raise/2" do
+    setup [:setup_session]
+
+    test "It can toggle the `is_raised` flag for a user in the Session", %{session: session} do
+      %User{id: uid, is_raised: is_raised} = Session.join(session, "Jane Doe")
+      assert is_raised == false
+
+      :ok = Session.toggle_raise(session, uid)
+      user = Session.get_user(session, uid)
+      assert user.is_raised
+    end
+
+    test "It will simply ignore a toggle for a user that does not exist", %{session: session} do
+      :ok = Session.toggle_raise(session, "does-not-exist")
+    end
+  end
+
+  describe "#leave/2" do
+    setup [:setup_session]
+
+    test "A user can leave the Session", %{session: session} do
+      %User{id: uid} = Session.join(session, "Jane Doe")
+
+      :ok = Session.leave(session, uid)
+      assert Session.get_user(session, uid) == nil
+    end
+
+    test "It will simply ignore a leave call for a user that does not exist", %{session: session} do
+      :ok = Session.leave(session, "does-not-exist")
+    end
+  end
+
+  describe "#get_state/1" do
+    setup [:setup_session]
+
+    test "Returns the current Session state", %{session: session} do
+      user1 = Session.join(session, "Jane Doe")
+      user2 = Session.join(session, "John Doe")
+      Session.toggle_raise(session, user1.id)
+
+      state = Session.get_state(session)
+      assert state.id != nil
+      assert state.users == [
+        Session.get_user(session, user2.id),
+        Session.get_user(session, user1.id)
+      ]
+    end
+  end
+
+  def setup_session(_) do
+    {:ok, session} = Session.start()
+    [session: session]
+  end
+end


### PR DESCRIPTION
To be used by HandRaiseWeb to start new sessions and manage session state (e.g. users in the party, raised hands).