### PR TITLE
fix(SessionServer): Make SessionServer API fully synchronous

### DIFF
--- a/lib/hand_raise_web/channels/session_channel.ex
+++ b/lib/hand_raise_web/channels/session_channel.ex
@@ -15,16 +15,16 @@ defmodule HandRaiseWeb.SessionChannel do
   def handle_in("set_user", %{"name" => name}, socket) do
     socket.assigns[:session]
     |> Session.join(id: socket.assigns[:user_id], name: name)
+    |> state_change(socket)
 
-    state_change(socket)
     {:reply, :ok, socket}
   end
 
   def handle_in("toggle_raised", %{"user_id" => uid}, socket) do
     socket.assigns[:session]
     |> Session.toggle_raise(uid)
+    |> state_change(socket)
 
-    state_change(socket)
     {:noreply, socket}
   end
 
@@ -33,16 +33,12 @@ defmodule HandRaiseWeb.SessionChannel do
 
   defp leave(socket) do
     sid = socket.assigns[:session]
+
     Session.leave(sid, socket.assigns[:user_id])
-    state_change(socket)
+    |> state_change(socket)
+
     Session.terminate_if_empty(sid)
   end
 
-  defp state_change(socket) do
-    state =
-      socket.assigns[:session]
-      |> Session.get_state()
-
-    broadcast(socket, "state_change", state)
-  end
+  defp state_change(state, socket), do: broadcast(socket, "state_change", state)
 end

--- a/test/hand_raise/session_server/session_test.exs
+++ b/test/hand_raise/session_server/session_test.exs
@@ -96,8 +96,7 @@ defmodule HandRaise.SessionServer.SessionTest do
 
     test "A new user can join the Session", %{session: session} do
       with uid <- UUID.generate(),
-           :ok <- Session.join(session, id: uid, name: "Jane Doe"),
-           %Session{users: [user]} <- Session.get_state(session)
+           %Session{users: [user]} <- Session.join(session, id: uid, name: "Jane Doe")
       do
         assert user.id == uid
         assert user.name == "Jane Doe"
@@ -111,16 +110,15 @@ defmodule HandRaise.SessionServer.SessionTest do
 
     test "It can toggle the `is_raised` flag for a user in the Session", %{session: session} do
       with uid <- UUID.generate(),
-           :ok <- Session.join(session, id: uid, name: "Jane Doe"),
-           :ok <- Session.toggle_raise(session, uid),
-           %Session{users: [user]} <- Session.get_state(session)
+           %Session{} <- Session.join(session, id: uid, name: "Jane Doe"),
+           %Session{users: [user]} <- Session.toggle_raise(session, uid)
       do
         assert user.is_raised
       end
     end
 
     test "It will simply ignore a toggle for a user that does not exist", %{session: session} do
-      :ok = Session.toggle_raise(session, "does-not-exist")
+      %Session{} = Session.toggle_raise(session, "does-not-exist")
     end
   end
 
@@ -129,16 +127,15 @@ defmodule HandRaise.SessionServer.SessionTest do
 
     test "A user can leave the Session", %{session: session} do
       with uid <- UUID.generate(),
-           :ok <- Session.join(session, id: uid, name: "Jane Doe"),
-           :ok <- Session.leave(session, uid),
-           %Session{users: users} <- Session.get_state(session)
+           %Session{} <- Session.join(session, id: uid, name: "Jane Doe"),
+           %Session{users: users} <- Session.leave(session, uid)
       do
         assert length(users) == 0
       end
     end
 
     test "It will simply ignore a leave call for a user that does not exist", %{session: session} do
-      :ok = Session.leave(session, "does-not-exist")
+      %Session{} = Session.leave(session, "does-not-exist")
     end
   end
 
@@ -147,9 +144,9 @@ defmodule HandRaise.SessionServer.SessionTest do
 
     test "Returns the current Session state", %{session: session} do
       with uid <- UUID.generate(),
-           :ok <- Session.join(session, id: uid, name: "Jane Doe"),
-           :ok <- Session.join(session, name: "John Doe"),
-           :ok <- Session.toggle_raise(session, uid),
+           %Session{} <- Session.join(session, id: uid, name: "Jane Doe"),
+           %Session{} <- Session.join(session, name: "John Doe"),
+           %Session{} <- Session.toggle_raise(session, uid),
            %Session{id: sid, users: users} <- Session.get_state(session)
       do
         assert sid != nil


### PR DESCRIPTION
Otherwise, casting join/leave/toggle actions and then immediately
broadcasting state could lead to race conditions down the line